### PR TITLE
Beacon loop activity_id == Uploaded

### DIFF
--- a/web_service/src/beacon_loop.rs
+++ b/web_service/src/beacon_loop.rs
@@ -1,46 +1,59 @@
 use crate::{
     db_service, discord,
-    strava::{self, beacon::Status},
+    strava::{
+        self,
+        beacon::{BeaconData, Status},
+    },
 };
 
 pub async fn process_beacon() {
     let troy_status = db_service::get_troy_status().await;
 
-    if troy_status.beacon_url.is_none() && troy_status.is_on_trail {
-        tracing::warn!(
-            "Troy status indicates on the trails but no beacon url found, clearing troy status"
-        );
-        db_service::set_troy_status(false).await;
-        return;
-    }
+    let beacon_url = match troy_status.beacon_url {
+        Some(url) => url,
+        None => {
+            if troy_status.is_on_trail {
+                tracing::warn!(
+                "Troy status indicates on the trails but no beacon url found, clearing troy status"
+            );
+                db_service::set_troy_status(false).await;
+            }
+            return;
+        }
+    };
 
-    let beacon_url = troy_status.beacon_url;
-    let beacon_data = match beacon_url {
-        Some(ref url) => match strava::beacon::get_beacon_data(url.to_string()).await {
-            Ok(data) => Some(data),
-            Err(e) => {
-                tracing::error!("Failed to get beacon data: {}", e);
-                None
+    let beacon_data = match strava::beacon::get_beacon_data(beacon_url.to_string()).await {
+        Ok(data) => data,
+        Err(e) => {
+            tracing::error!("Failed to get beacon data: {}", e);
+            return;
+        }
+    };
+
+    let BeaconData {
+        status,
+        activity_id,
+        update_time,
+        ..
+    } = match beacon_data.activity_id {
+        Some(_id) => match beacon_data.status {
+            Status::Uploaded | Status::Dicarded => beacon_data,
+            _ => {
+                // if activty ID exists and status is not uploaded or discarded,
+                // then the beacon data might be wrong
+                let mut beacon_data = beacon_data;
+                beacon_data.status = Status::Uploaded;
+                beacon_data
             }
         },
-        None => None,
+        None => {
+            tracing::warn!("Failed to get beacon data: activity id not found");
+            return;
+        }
     };
 
-    let (activity_status, activity_id) = match beacon_data.clone() {
-        Some(data) => (Some(data.status), data.activity_id),
-        None => (None, None),
-    };
-
-    // check if activity_id has already been populated
-    // strava is stupid and sometimes doesn't update beacon status
-    // assume the activity was uploaded if true
-    let activity_status = match activity_id {
-        Some(_) => Some(Status::Uploaded),
-        _ => activity_status,
-    };
-
-    match activity_status {
-        Some(Status::Active | Status::AutoPaused | Status::ManualPaused) => {
+    match status {
+        Status::Active | Status::AutoPaused | Status::ManualPaused => {
             tracing::trace!("Beacon data indicates troy is active on the trails");
             db_service::set_troy_status(true).await;
             if !troy_status.is_on_trail {
@@ -48,7 +61,7 @@ pub async fn process_beacon() {
                 discord::send_starting_webhook(beacon_url).await;
             }
         }
-        Some(Status::Uploaded) => {
+        Status::Uploaded => {
             tracing::info!("Beacon data indicates activity uploaded, clearing beacon url");
             db_service::set_beacon_url(None).await;
             if troy_status.is_on_trail {
@@ -56,7 +69,7 @@ pub async fn process_beacon() {
                 discord::send_end_webhook(activity_id).await;
             }
         }
-        Some(Status::Dicarded) => {
+        Status::Dicarded => {
             tracing::info!(
                 "Beacon data indicates activity was discarded, clearing troy status and beacon url"
             );
@@ -66,10 +79,9 @@ pub async fn process_beacon() {
                 discord::send_discard_webhook().await;
             }
         }
-        Some(Status::NotStarted) => {
+        Status::NotStarted => {
             tracing::info!("Beacon data indicates activity is not started yet");
             let diff = {
-                let update_time = beacon_data.unwrap().update_time;
                 let update_time = update_time.datetime();
                 let now = chrono::Utc::now();
                 now - update_time
@@ -81,7 +93,6 @@ pub async fn process_beacon() {
                 db_service::set_beacon_url(None).await;
             }
         }
-        None => {}
         _ => {
             tracing::warn!("Beacon data indicates unknown status");
         }

--- a/web_service/src/beacon_loop.rs
+++ b/web_service/src/beacon_loop.rs
@@ -31,6 +31,14 @@ pub async fn process_beacon() {
         None => (None, None),
     };
 
+    // check if activity_id has already been populated
+    // strava is stupid and sometimes doesn't update beacon status
+    // assume the activity was uploaded if true
+    let activity_status = match activity_id {
+        Some(_) => Some(Status::Uploaded),
+        _ => activity_status,
+    };
+
     match activity_status {
         Some(Status::Active | Status::AutoPaused | Status::ManualPaused) => {
             tracing::trace!("Beacon data indicates troy is active on the trails");

--- a/web_service/src/discord.rs
+++ b/web_service/src/discord.rs
@@ -8,16 +8,14 @@ use crate::{
 };
 
 struct OnTrailsNotification {
-    beacon_url: Option<String>,
+    beacon_url: String,
 }
 
 impl From<OnTrailsNotification> for DiscordEmbed {
     fn from(val: OnTrailsNotification) -> Self {
         let mut embed: DiscordEmbed = DiscordEmbed::default();
         embed.title("Troy is on the trails!");
-        if let Some(beacon_url) = &val.beacon_url {
-            embed.description(beacon_url);
-        }
+        embed.description(&val.beacon_url);
         embed
     }
 }
@@ -338,7 +336,7 @@ async fn send_webhook(message: impl Into<DiscordMessage>) {
     }
 }
 
-pub async fn send_starting_webhook(beacon_url: Option<String>) {
+pub async fn send_starting_webhook(beacon_url: String) {
     send_webhook(OnTrailsNotification { beacon_url }).await;
 }
 

--- a/web_service/src/route_handlers/trail_check.rs
+++ b/web_service/src/route_handlers/trail_check.rs
@@ -28,7 +28,7 @@ impl<'de> Deserialize<'de> for TrailStatus {
     {
         struct TrailStatusVisitor;
 
-        impl<'de> Visitor<'de> for TrailStatusVisitor {
+        impl Visitor<'_> for TrailStatusVisitor {
             type Value = TrailStatus;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/web_service/src/strava/beacon.rs
+++ b/web_service/src/strava/beacon.rs
@@ -109,7 +109,7 @@ impl<'de> Deserialize<'de> for EpochDateTime {
     {
         struct EpochDateTimeVisitor;
 
-        impl<'de> Visitor<'de> for EpochDateTimeVisitor {
+        impl Visitor<'_> for EpochDateTimeVisitor {
             type Value = EpochDateTime;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
- Updates beacon loop control flow to stop early if a beacon_url wasn't actually provided or if it doesn't yield any data
- Add checks for 'activity_id'. The various beacon statuses are cool and all but they can also be wrong so use activity_id's presence as the source of truth for whether a ride has been uploaded or not